### PR TITLE
fix: add bound checks before potential oob accesses to byte arrays

### DIFF
--- a/lms/lms/private.go
+++ b/lms/lms/private.go
@@ -163,6 +163,10 @@ func (priv *LmsPrivateKey) Q() uint32 {
 // LmsPrivateKeyFromBytes returns an LmsPrivateKey that represents b.
 // This is the inverse of the ToBytes() method on the LmsPrivateKey object.
 func LmsPrivateKeyFromBytes(b []byte) (LmsPrivateKey, error) {
+	if len(b) < 8 {
+		return LmsPrivateKey{}, errors.New("LmsPrivateKeyFromBytes(): Input is too short")
+	}
+
 	// The typecode is bytes 0-3 (4 bytes)
 	typecode, err := common.Uint32ToLmsType(binary.BigEndian.Uint32(b[0:4])).LmsType()
 	if err != nil {

--- a/lms/lms/private_test.go
+++ b/lms/lms/private_test.go
@@ -28,7 +28,7 @@ func TestPKTreeKAT1(t *testing.T) {
 	otstc := common.LMOTS_SHA256_N32_W4
 
 	lms_priv, err := lms.NewPrivateKeyFromSeed(tc, otstc, common.ID(id), seed)
-  assert.NoError(t, err)
+	assert.NoError(t, err)
 	lms_pub := lms_priv.Public()
 
 	assert.Equal(t, lms_pub.ID(), common.ID(id))
@@ -97,7 +97,7 @@ func TestSignKAT1(t *testing.T) {
 
 	// Generate a signature
 	sig, err := lms_priv.Sign(msg, nil)
-  assert.NoError(t, err)
+	assert.NoError(t, err)
 
 	// Assert incremented
 	assert.Equal(t, lms_priv.Q(), uint32(6))
@@ -137,4 +137,12 @@ func TestSignKAT1(t *testing.T) {
 	// Flipping a bit in the signature should yield a false
 	result = lms_public.Verify(msg, sig2)
 	assert.False(t, result)
+}
+
+func TestShortSignatureFromBytes(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		data := make([]byte, i)
+		_, err := lms.LmsSignatureFromBytes(data)
+		assert.Error(t, err)
+	}
 }

--- a/lms/lms/public.go
+++ b/lms/lms/public.go
@@ -135,16 +135,16 @@ func LmsPublicKeyFromByes(b []byte) (LmsPublicKey, error) {
 	if err != nil {
 		return LmsPublicKey{}, err
 	}
+	// Ensure b is the correct length
+	lmsparams := typecode.LmsParams()
+	if uint64(len(b)) != lmsparams.M+24 {
+		return LmsPublicKey{}, errors.New("LmsPublicKeyFromBytes(): invalid key length")
+	}
+
 	// The ID is bytes 8-23 (16 bytes)
 	id := common.ID(b[8:24])
 	// The public key, k, is the remaining bytes
 	k := b[24:]
-
-	// Ensure k is the correct length
-	lmsparams := typecode.LmsParams()
-	if uint64(len(k)) != lmsparams.M {
-		return LmsPublicKey{}, errors.New("LmsPublicKeyFromBytes(): invalid key length")
-	}
 
 	return LmsPublicKey{
 		typecode: typecode,

--- a/lms/lms/signature.go
+++ b/lms/lms/signature.go
@@ -42,7 +42,11 @@ func NewLmsSignature(tc common.LmsAlgorithmType, q uint32, otsig ots.LmsOtsSigna
 // LmsSignatureFromBytes returns an LmsSignature represented by b.
 // This is the inverse of the ToBytes() on LmsSignature.
 func LmsSignatureFromBytes(b []byte) (LmsSignature, error) {
-  var err error
+	if len(b) < 8 {
+		return LmsSignature{}, errors.New("LmsSignatureFromBytes(): Signature is too short")
+	}
+
+	var err error
 
 	// The internal coutnter is bytes 0-3
 	q := binary.BigEndian.Uint32(b[0:4])
@@ -51,9 +55,9 @@ func LmsSignatureFromBytes(b []byte) (LmsSignature, error) {
 	otstc := common.Uint32ToLmsType(binary.BigEndian.Uint32(b[4:8]))
 	// Return error if not a valid LM-OTS algorithm:
 	_, err = otstc.LmsOtsType()
-  if err != nil {
-    return LmsSignature{}, err
-  }
+	if err != nil {
+		return LmsSignature{}, err
+	}
 
 	// 4 + LM-OTS signature length is the first byte after the LM-OTS sig
 	otsigmax := 4 + otstc.LmsOtsSigLength()
@@ -65,9 +69,9 @@ func LmsSignatureFromBytes(b []byte) (LmsSignature, error) {
 	typecode := common.Uint32ToLmsType(binary.BigEndian.Uint32(b[otsigmax : otsigmax+4]))
 	// Return error if not a valid LMS algorithm
 	_, err = typecode.LmsType()
-  if err != nil {
-    return LmsSignature{}, err
-  }
+	if err != nil {
+		return LmsSignature{}, err
+	}
 
 	// With both typecodes, we can calculate the total signature length
 	var siglen = typecode.LmsSigLength(otstc)

--- a/lms/lms/signature_test.go
+++ b/lms/lms/signature_test.go
@@ -1,0 +1,16 @@
+package lms_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/trailofbits/lms-go/lms/lms"
+)
+
+func TestSignatureFromBytes(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		bytes := make([]byte, i)
+		_, err := lms.LmsSignatureFromBytes(bytes)
+		assert.Error(t, err)
+	}
+}

--- a/lms/ots/ots_test.go
+++ b/lms/ots/ots_test.go
@@ -108,3 +108,11 @@ func TestDoubleSign(t *testing.T) {
 	_, err = ots_priv.Sign([]byte("example2"), nil)
 	assert.Error(t, err)
 }
+
+func TestOtsPublicKeyFromBytes(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		bytes := make([]byte, i)
+		_, err := ots.LmsOtsPublicKeyFromByes(bytes)
+		assert.Error(t, err)
+	}
+}

--- a/lms/ots/public.go
+++ b/lms/ots/public.go
@@ -107,6 +107,10 @@ func (pub *LmsOtsPublicKey) Key() []byte {
 // LmsOtsPublicKeyFromBytes returns an LmsOtsPublicKey that represents b.
 // This is the inverse of the ToBytes() method on the LmsOtsPublicKey object.
 func LmsOtsPublicKeyFromByes(b []byte) (LmsOtsPublicKey, error) {
+	if len(b) < 4 {
+		return LmsOtsPublicKey{}, errors.New("LmsOtsPublicKeyFromBytes(): OTS public key too short")
+	}
+
 	// The typecode is bytes 0-3 (4 bytes)
 	typecode, err := common.Uint32ToLmsType(binary.BigEndian.Uint32(b[0:4])).LmsOtsType()
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/trailofbits/lms-go/issues/8